### PR TITLE
various improvements

### DIFF
--- a/app/guide/interfaces.vmd
+++ b/app/guide/interfaces.vmd
@@ -137,7 +137,7 @@ The current syntax is closer to the way Vale internally thinks about interfaces.
  * We could have override methods inside the `impl`.
 
 ////
-```
+```Vale
 interface Bipedal {
   fn hop(self) void;
   fn skip(self) void;
@@ -168,10 +168,10 @@ interface MaybeInt sealed { }
 // structs can implement MaybeInt.
 
 struct NoInt { }
-impl None for MaybeInt;
+impl MaybeInt for None;
 
 struct SomeInt { value int; }
-impl SomeInt for MaybeInt;
+impl MaybeInt for SomeInt;
 ```
 >>>>
 

--- a/app/guide/interfaces.vmd
+++ b/app/guide/interfaces.vmd
@@ -137,7 +137,7 @@ The current syntax is closer to the way Vale internally thinks about interfaces.
  * We could have override methods inside the `impl`.
 
 ////
-```Vale
+```
 interface Bipedal {
   fn hop(self) void;
   fn skip(self) void;

--- a/app/guide/introduction.vmd
+++ b/app/guide/introduction.vmd
@@ -70,7 +70,7 @@ Hello Antarctica!
 >>>>
 
 <slice>
-#running: You can put the code into e.g. `hello.vale` and invoke the compiler with `python3 valec.py hello.vale`. (After 0.1, it will simply be `vale build hello.vale`.)
+#running: You can put the code into e.g. `hello.vale` and invoke the compiler with `python3 valec.py build hello.vale`. (After 0.1, it will simply be `vale build hello.vale`.)
 
 That will produce an executable named `hello.exe` (on Windows) or `hello` (on Mac or Linux).
 </slice>

--- a/app/guide/patterns.vmd
+++ b/app/guide/patterns.vmd
@@ -122,7 +122,7 @@ Here, we're using a match statement to check what the user entered.
 
 In patterns, `_` matches any incoming data and discards it.
 ////
-```
+```Vale
 fn main() export {
   mat inputInt() {
     1 { println("One!"); }
@@ -138,7 +138,7 @@ We can even check an incoming interface, to see what substruct it is.
 
 We can even destructure it at the same time!
 ////
-```
+```Vale
 interface ISpaceship { }
 
 struct Firefly { name str; }

--- a/app/guide/patterns.vmd
+++ b/app/guide/patterns.vmd
@@ -122,7 +122,7 @@ Here, we're using a match statement to check what the user entered.
 
 In patterns, `_` matches any incoming data and discards it.
 ////
-```Vale
+```
 fn main() export {
   mat inputInt() {
     1 { println("One!"); }
@@ -138,7 +138,7 @@ We can even check an incoming interface, to see what substruct it is.
 
 We can even destructure it at the same time!
 ////
-```Vale
+```
 interface ISpaceship { }
 
 struct Firefly { name str; }

--- a/app/guide/regions.vmd
+++ b/app/guide/regions.vmd
@@ -84,7 +84,7 @@ We can make a mutexed region with the `Mutex` function.
 
 It accepts a *regioned object*. A regioned object is an object where all of its (directly or indirectly) owned objects refer only to each other and are referred to only by each other.
 
-Here, we're making an regioned object with a region call, the `'a makeGame()`.
+Here, we're making a regioned object with a region call, the `'a makeGame()`.
 
 `Mutex` will take the regioned object, and wrap it in a `Mutex` object.
 

--- a/app/guide/structs.vmd
+++ b/app/guide/structs.vmd
@@ -222,10 +222,13 @@ struct Spaceship imm {
 
 fn main() export {
   ship = Spaceship("Serenity", 2);
+  ship2 = ship;
   println(ship.numWings);
+  println(ship2.numWings);
 }
 ```
 ```stdout
+Spaceship("Serenity", 2)
 Spaceship("Serenity", 2)
 ```
 >>>>

--- a/app/guide/structs.vmd
+++ b/app/guide/structs.vmd
@@ -228,8 +228,8 @@ fn main() export {
 }
 ```
 ```stdout
-Spaceship("Serenity", 2)
-Spaceship("Serenity", 2)
+2
+2
 ```
 >>>>
 

--- a/app/home.vmd
+++ b/app/home.vmd
@@ -16,7 +16,7 @@ path: home
 Vale's goal is to show the world that speed and safety can be easy. Vale is:
 
  * *Fast:* Vale uses an entirely new approach to memory management: [generational references](/blog/generational-references), which have zero aliasing costs and no garbage collection pauses.
- * *Fearless:* It is the [safest native language](/blog/fearless): zero `unsafe`, region isolation, extern boundaries, and dependency extern whitelisting.
+ * *Fearless:* It is the [safest native (AOT compiled) language](/blog/fearless): zero `unsafe`, region isolation, extern boundaries, and dependency extern whitelisting.
  * *Flexible:* Its new take on [regions](/guide/regions) enables alternate memory management and allocation strategies, with the [region borrow checker](/blog/zero-cost-refs-regions) enabling seamless, fast, and _easy_ interop between them.
 
 
@@ -44,7 +44,7 @@ Read comparisons with [C++, Javascript, and Rust](/blog/comparisons)!
  * [Generational References](/blog/generational-references) (Jan 2)
  * [Hybrid-Generational Memory](/blog/hybrid-generational-memory) (Jan 2)
  * [Zero Cost References with Regions](/blog/zero-cost-refs-regions) (Jul 29 2020)
- * [Next Steps for Single Ownership and RAII](/blog/next-steps-raii) (Jul 15 2020)
+ * [Next Steps for Single Ownership and RAII](/blog/raii-next-steps) (Jul 15 2020)
  * [Announcing Vale!](https://www.reddit.com/r/ProgrammingLanguages/comments/hplj2i/vale/) (Jul 11 2020)
 
 

--- a/app/home.vmd
+++ b/app/home.vmd
@@ -15,8 +15,8 @@ path: home
 
 Vale's goal is to show the world that speed and safety can be easy. Vale is:
 
- * *Fast:* Vale uses an entirely new approach to memory management: [generational references](/blog/generational-references), which have zero aliasing costs and no garbage collection pauses.
- * *Fearless:* It is the [safest native (AOT compiled) language](/blog/fearless): zero `unsafe`, region isolation, extern boundaries, and dependency extern whitelisting.
+ * *Fast:* Vale is an AOT compiled language that uses an entirely new approach to memory management: [generational references](/blog/generational-references), which have zero aliasing costs and no garbage collection pauses.
+ * *Fearless:* It is the [safest native language](/blog/fearless): zero `unsafe`, region isolation, extern boundaries, and dependency extern whitelisting.
  * *Flexible:* Its new take on [regions](/guide/regions) enables alternate memory management and allocation strategies, with the [region borrow checker](/blog/zero-cost-refs-regions) enabling seamless, fast, and _easy_ interop between them.
 
 


### PR DESCRIPTION
(0) Intro page:
compiler with python3 valec.py build hello.vale     <-- command changed in release v 0.1.1

(1) Sealed interfaces:
- impl SomeInt for MaybeInt;   should be according to:
impl interface for struct

so:  impl None for MaybeInt; --> impl MayBeInt for NoInt
	impl SomeInt for MaybeInt; --> impl MayBeInt for SomeInt

(2) Regions: Here, we're making an regioned object   <-- a

 (3) On frontpage:  native (AOT compiled)

<-- A question I saw somewhere was: Is it interpreted or compiled, AOT or JIT, native or byte code? This info should be on the front page; adding AOT compiled to clarify

 (4) Structs page:
immutable_structs
--> added ship2 to more clearly show that immutable structs can have multiple owning references

 (5) Match statement:
on page: no highlighting ?
same on page: Interfaces: Simplified syntax

--> Added Vale after ```
Perhaps this was intentionally left out? What does ```Vale: notest means?
If it was intentional to leave Planned Feature code without syntax highlighting, this is not consistent with the Interfaces page, where highlighting is done in Planned Features code.

(6) Bad link:
- on homepage: link to Next Steps for Single ownership ... gives Page not found error with the bad link: https://vale.dev/blog/next-steps-raii
The correct link is: https://vale.dev/blog/raii-next-steps

